### PR TITLE
Add undocumented media type & source

### DIFF
--- a/mal-api/src/anime/responses.rs
+++ b/mal-api/src/anime/responses.rs
@@ -144,6 +144,7 @@ pub enum Source {
     MixedMedia, // undocumented source...
     Radio,
     Music,
+    WebNovel // undocumented source...
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]

--- a/mal-api/src/anime/responses.rs
+++ b/mal-api/src/anime/responses.rs
@@ -68,6 +68,7 @@ pub enum AnimeMediaType {
     Special,
     Ona,
     Music,
+    Pv, // undocumented media type...
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
These missing values can be tested by running the "anime" example, and replacing "One piece" by "Jujutsu Kaisen Official PVs"